### PR TITLE
Modify `db` to use in-memory database when `DEV_MODE=test`

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,12 +1,55 @@
 import mongoose from "mongoose";
 import colors from "colors";
-const connectDB = async () => {
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+let mongoServer
+
+export const connectDB = async () => {
     try {
-        const conn = await mongoose.connect(process.env.MONGO_URL);
+        let conn;
+
+        if (process.env.DEV_MODE === "development") {
+            // Connect to the actual MongoDB
+            conn = await mongoose.connect(process.env.MONGO_URL);
+        } else if (process.env.DEV_MODE === "test") {
+            // Connect to the in-memory database
+            mongoServer = await MongoMemoryServer.create({
+                instance: {
+                    port: 27017,
+                    dbName: "ecommerce-test"
+                }
+            });
+            const uri = await mongoServer.getUri();
+
+            const mongooseOpts = {
+                useNewUrlParser: true,
+                useUnifiedTopology: true
+            };
+
+            conn = await mongoose.connect(uri, mongooseOpts);
+        } else {
+            throw new Error("Invalid DEV_MODE");            
+        }
         console.log(`Connected To Mongodb Database ${conn.connection.host}`.bgMagenta.white);
     } catch (error) {
         console.log(`Error in Mongodb ${error}`.bgRed.white);
     }
 };
 
-export default connectDB;
+export const disconnectDB = async () => {
+    try {
+        if (process.env.DEV_MODE === "development") {
+            await mongoose.disconnect();
+        } else if (process.env.DEV_MODE === "test") {
+            // Drop database, close the connection and stop mongodb
+            await mongoose.connection.dropDatabase();
+            await mongoose.connection.close();
+            await mongoServer.stop();
+        } else {
+            throw new Error("Invalid DEV_MODE");
+        }
+        console.log("Disconnected from Mongodb Database".bgMagenta.white);
+    } catch (error) {
+        console.log(`Error in disconnecting Mongodb ${error}`.bgRed.white);
+    }
+}

--- a/config/db.test.js
+++ b/config/db.test.js
@@ -1,45 +1,212 @@
 import mongoose from "mongoose";
-import connectDB from "./db";
+import { connectDB, disconnectDB } from "./db";
+import { MongoMemoryServer } from "mongodb-memory-server";
 
 jest.mock("mongoose");
+jest.mock("mongodb-memory-server", () => ({
+    MongoMemoryServer: {
+        create: jest.fn(),
+    }
+}));
+
+const mockMongoMemoryServer = {
+    getUri: jest.fn().mockReturnValue("mongodb://127.0.0.1:27017/"),
+    stop: jest.fn()
+};
 
 describe("Mongoose Database", () => {
     beforeAll(() => {
         console.log = jest.fn();
-    })
+    });
 
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    test("if it connects to the database", async () => {
-        // Arrange
-        const mockConn = {
-            connection: {
-                host: "localhost"
-            }
-        };
-        mongoose.connect = jest.fn().mockResolvedValue(mockConn);
+    describe("Database Connection", () => {
+        describe("when DEV_MODE = development", () => {
+            beforeAll(() => {
+                process.env.DEV_MODE = "development";
+            });
 
-        // Act
-        await connectDB();
+            it("should connect to the database", async () => {
+                // Arrange
+                const mockConn = {
+                    connection: {
+                        host: "localhost"
+                    }
+                };
+                mongoose.connect = jest.fn().mockResolvedValue(mockConn);
 
-        // Assert
-        expect(mongoose.connect).toHaveBeenCalledWith(process.env.MONGO_URL);
-        expect(console.log).toHaveBeenCalledWith(`Connected To Mongodb Database ${mockConn.connection.host}`.bgMagenta.white);
+                // Act
+                await connectDB();
+
+                // Assert
+                expect(mongoose.connect).toHaveBeenCalledWith(process.env.MONGO_URL);
+                expect(console.log).toHaveBeenCalledWith(`Connected To Mongodb Database ${mockConn.connection.host}`.bgMagenta.white);
+            });
+
+            it("should return an error if db url is missing", async () => {
+                // Arrange 
+                const mockError = new Error("Connection failed");
+                mongoose.connect = jest.fn().mockRejectedValue(mockError);
+
+                // Act
+                await connectDB();
+
+                // Assert
+                expect(mongoose.connect).toHaveBeenCalledWith(process.env.MONGO_URL);
+                expect(console.log).toHaveBeenCalledWith(`Error in Mongodb ${mockError}`.bgRed.white);
+            });
+        });
+
+        describe("when DEV_NODE = test", () => {
+            beforeAll(() => {
+                process.env.DEV_MODE = "test";
+            });
+
+            it("should connect to the in-memory database", async () => {
+                // Arrange
+                const mockConn = {
+                    connection: {
+                        host: "localhost"
+                    }
+                };
+                MongoMemoryServer.create.mockResolvedValueOnce(mockMongoMemoryServer);
+                mongoose.connect.mockResolvedValueOnce(mockConn);
+
+                // Act
+                await connectDB();
+
+                // Assert
+                expect(MongoMemoryServer.create).toHaveBeenCalled();
+                expect(mongoose.connect).toHaveBeenCalledWith("mongodb://127.0.0.1:27017/", {
+                    useNewUrlParser: true,
+                    useUnifiedTopology: true
+                });
+                expect(console.log).toHaveBeenCalledWith(`Connected To Mongodb Database ${mockConn.connection.host}`.bgMagenta.white);
+            });
+        });
+
+        describe("when DEV_MODE = random", () => {
+            beforeAll(async () => {
+                process.env.DEV_MODE = "random";
+            });
+
+            it("should throw an error", async () => {
+                // Arrange
+                const mockError = new Error("Invalid DEV_MODE");
+
+                // Act
+                await connectDB();
+
+                // Assert
+                expect(() => {
+                    if (process.env.DEV_MODE !== "development" && process.env.DEV_MODE !== "test") {
+                        throw new Error("Invalid DEV_MODE");
+                    }
+                }).toThrow(mockError);
+                expect(console.log).toHaveBeenCalledWith(`Error in Mongodb ${mockError}`.bgRed.white);
+            });
+        });
+
     });
 
-    test("should return an error if db url is missing", async () => {
-        // Arrange 
-        const mockError = new Error("Connection failed");
-        mongoose.connect = jest.fn().mockRejectedValue(mockError);
+    describe("Database Disconnection", () => {
+        describe("when DEV_MODE = development", () => {
+            beforeAll(async () => {
+                process.env.DEV_MODE = "development";
+                await connectDB();
+            });
 
-        // Act
-        await connectDB();
+            it("should disconnect from the database", async () => {
+                // Arrange
+                mongoose.disconnect = jest.fn().mockResolvedValue(true);
 
-        // Assert
-        expect(mongoose.connect).toHaveBeenCalledWith(process.env.MONGO_URL);
-        expect(console.log).toHaveBeenCalledWith(`Error in Mongodb ${mockError}`.bgRed.white);
+                // Act
+                await disconnectDB();
+
+                // Assert
+                expect(mongoose.disconnect).toHaveBeenCalled();
+                expect(console.log).toHaveBeenCalledWith("Disconnected from Mongodb Database".bgMagenta.white);
+            });
+
+            it("should return an error", async () => {
+                // Arrange
+                const mockError = new Error("mock error");
+                mongoose.disconnect = jest.fn().mockRejectedValue(mockError);
+
+                // Act
+                await disconnectDB();
+
+                // Assert
+                expect(mongoose.disconnect).toHaveBeenCalled();
+                expect(console.log).toHaveBeenCalledWith(`Error in disconnecting Mongodb ${mockError}`.bgRed.white);
+            });
+        });
+
+        describe("when DEV_MODE = test", () => {
+            beforeAll(async () => {
+                process.env.DEV_MODE = "test";
+
+                const mockConn = {
+                    connection: {
+                        host: "localhost"
+                    }
+                };
+                MongoMemoryServer.create.mockResolvedValueOnce(mockMongoMemoryServer);
+                mongoose.connect.mockResolvedValueOnce(mockConn);
+
+                await connectDB();
+
+                mongoose.connection = {
+                    dropDatabase: jest.fn().mockResolvedValue(true),
+                    close: jest.fn().mockResolvedValue(true),
+                };
+            });
+
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
+
+            it("should disconnect from the in-memory database", async () => {
+                // Arrange
+                mongoose.connection.dropDatabase = jest.fn().mockResolvedValue(true);
+                mongoose.connection.close = jest.fn().mockResolvedValue(true);
+                mockMongoMemoryServer.stop = jest.fn().mockResolvedValue(true);
+
+                // Act
+                await disconnectDB();
+
+                // Assert
+                expect(mongoose.connection.dropDatabase).toHaveBeenCalled();
+                expect(mongoose.connection.close).toHaveBeenCalled();
+                expect(mockMongoMemoryServer.stop).toHaveBeenCalled();
+                expect(console.log).toHaveBeenCalledWith("Disconnected from Mongodb Database".bgMagenta.white);
+            });
+        });
+
+        describe("when DEV_MODE = random", () => {
+            beforeAll(async () => {
+                process.env.DEV_MODE = "random";
+                await connectDB();
+            });
+
+            it("should throw an error", async () => {
+                // Arrange
+                const mockError = new Error("Invalid DEV_MODE");
+
+                // Act
+                await disconnectDB();
+
+                // Assert
+                expect(() => {
+                    if (process.env.DEV_MODE !== "development" && process.env.DEV_MODE !== "test") {
+                        throw new Error("Invalid DEV_MODE");
+                    }
+                }).toThrow(mockError);
+                expect(console.log).toHaveBeenCalledWith(`Error in disconnecting Mongodb ${mockError}`.bgRed.white);
+            });
+        });
     });
-
 });

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ import express from "express";
 import colors from "colors";
 import dotenv from "dotenv";
 import morgan from "morgan";
-import connectDB from "./config/db.js";
+import { connectDB, disconnectDB } from "./config/db.js";
 import authRoutes from './routes/authRoute.js'
 import categoryRoutes from './routes/categoryRoutes.js'
 import productRoutes from './routes/productRoutes.js'
@@ -34,6 +34,25 @@ app.get('/', (req,res) => {
 
 const PORT = process.env.PORT || 6060;
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
     console.log(`Server running on ${process.env.DEV_MODE} mode on ${PORT}`.bgCyan.white);
+});
+
+const cleanup = async () => {
+    server.close(async () => {
+        console.log("HTTP server closed");
+        await disconnectDB();
+        process.exit(0); // Exit gracefully
+    });    
+}
+
+// Handle shutdown signals
+process.on("SIGINT", async () => {
+    console.log("SIGINT signal received: closing HTTP server");
+    await cleanup();
+});
+
+process.on("SIGTERM", async () => {
+    console.log("SIGTERM signal received: closing HTTP server");
+    await cleanup();
 });


### PR DESCRIPTION
- Add test cases to cover the new code
- Throws an error if `DEV_MODE` is invalid value

> [!IMPORTANT]
> `DEV_MODE` for jest is `development` by default.
> If you wish to use in-memory database, set `DEV_MODE` value to `test` in your test files.
>
> For example,
> ```
> beforeAll(() => {
>     process.env.DEV_MODE = "test"
> };
> ```